### PR TITLE
Adopt code generator changes in k8s-openapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ v4_3 = [ "k8s-openapi/v1_16" ]
 v4_4 = [ "k8s-openapi/v1_17" ]
 
 [patch.crates-io]
-k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi", branch="openshift" }
+k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi", branch="master" }
 
 [package.metadata.docs.rs]
 features = ["v4_4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ v4_3 = [ "k8s-openapi/v1_16" ]
 v4_4 = [ "k8s-openapi/v1_17" ]
 
 [patch.crates-io]
-k8s-openapi = { git = "https://github.com/ctron/k8s-openapi", branch="feature/openshift_api_2" }
+k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi", branch="openshift" }
 
 [package.metadata.docs.rs]
 features = ["v4_4"]

--- a/openshift-openapi-codegen/Cargo.toml
+++ b/openshift-openapi-codegen/Cargo.toml
@@ -17,5 +17,4 @@ serde_derive = "1"
 k8s-openapi-codegen-common = { version = "0.8", features = ["serde"] }
 
 [patch.crates-io]
-#k8s-openapi-codegen-common = { git = "https://github.com/ctron/k8s-openapi", branch = "feature/openshift_api_2" }
-k8s-openapi-codegen-common = { git = "https://github.com/Arnavion/k8s-openapi", branch="openshift" }
+k8s-openapi-codegen-common = { git = "https://github.com/Arnavion/k8s-openapi", branch="master" }

--- a/openshift-openapi-codegen/Cargo.toml
+++ b/openshift-openapi-codegen/Cargo.toml
@@ -17,4 +17,5 @@ serde_derive = "1"
 k8s-openapi-codegen-common = { version = "0.8", features = ["serde"] }
 
 [patch.crates-io]
-k8s-openapi-codegen-common = { git = "https://github.com/ctron/k8s-openapi", branch = "feature/openshift_api_2" }
+#k8s-openapi-codegen-common = { git = "https://github.com/ctron/k8s-openapi", branch = "feature/openshift_api_2" }
+k8s-openapi-codegen-common = { git = "https://github.com/Arnavion/k8s-openapi", branch="openshift" }

--- a/openshift-openapi-codegen/src/fixups/openshift.rs
+++ b/openshift-openapi-codegen/src/fixups/openshift.rs
@@ -10,17 +10,15 @@ pub(crate) fn remove_legacy_gvk(spec: &mut crate::swagger20::Spec) -> Result<(),
             continue;
         }
 
-        if let Some(gvks) = &mut v.kubernetes_group_kind_versions {
-            gvks.retain(|gvk| {
-                // drop the legacy, empty group
-                if gvk.group.is_empty() {
-                    found = true;
-                    false
-                } else {
-                    true
-                }
-            });
-        }
+        v.kubernetes_group_kind_versions.retain(|gvk| {
+            // drop the legacy, empty group
+            if gvk.group.is_empty() {
+                found = true;
+                false
+            } else {
+                true
+            }
+        });
     }
 
     if found {
@@ -52,19 +50,15 @@ pub(crate) fn fix_imagestream_secrets_list(
             continue;
         }
 
-        if let Some(gvks) = &mut v.kubernetes_group_kind_versions {
-            if gvks.len() > 1 {
-                gvks.retain(|gvk| {
-                    // drop the legacy, empty group
-                    if gvk.group == "image.openshift.io" && gvk.kind == "SecretList" {
-                        found = true;
-                        false
-                    } else {
-                        true
-                    }
-                });
+        v.kubernetes_group_kind_versions.retain(|gvk| {
+            // drop the legacy, empty group
+            if gvk.group == "image.openshift.io" && gvk.kind == "SecretList" {
+                found = true;
+                false
+            } else {
+                true
             }
-        }
+        });
     }
 
     if found {

--- a/openshift-openapi-codegen/src/fixups/special.rs
+++ b/openshift-openapi-codegen/src/fixups/special.rs
@@ -1351,3 +1351,39 @@ pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), cr
 
     Ok(())
 }
+
+// The `metadata` property of resource types is generally not optional, so override the property to be required.
+// For situations like PATCH requests where the property *is* optional, sending an empty object works the same.
+pub(crate) fn resource_metadata_not_optional(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+    let mut found = false;
+
+    for definition in spec.definitions.values_mut() {
+        if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+            let mut has_api_version = false;
+            let mut has_kind = false;
+            let mut has_optional_metadata = false;
+
+            for (name, (_, required)) in &mut *properties {
+                has_api_version = has_api_version || name.0 == "apiVersion";
+                has_kind = has_kind || name.0 == "kind";
+                has_optional_metadata = has_optional_metadata || (name.0 == "metadata" && !*required);
+                if has_api_version && has_kind && has_optional_metadata {
+                    break;
+                }
+            }
+
+            if has_api_version && has_kind && has_optional_metadata {
+                let metadata = properties.get_mut(&crate::swagger20::PropertyName("metadata".to_owned())).unwrap();
+                metadata.1 = true;
+                found = true;
+            }
+        }
+    }
+
+    if found {
+        Ok(())
+    }
+    else {
+        Err("never applied override to make resource metadata non-optional".into())
+    }
+}

--- a/openshift-openapi-codegen/src/fixups/special.rs
+++ b/openshift-openapi-codegen/src/fixups/special.rs
@@ -39,7 +39,7 @@ pub(crate) fn create_delete_optional(
             kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::DeleteOptional(
                 delete_optional_properties,
             )),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     );
@@ -94,10 +94,9 @@ pub(crate) fn create_optionals(spec: &mut crate::swagger20::Spec) -> Result<(), 
                 ),
                 kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                     path: type_name.to_owned(),
-                    relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                     can_be_default: None,
                 }),
-                kubernetes_group_kind_versions: None,
+                kubernetes_group_kind_versions: vec![],
                 has_corresponding_list_type: false,
             },
         });
@@ -183,7 +182,7 @@ pub(crate) fn create_optionals(spec: &mut crate::swagger20::Spec) -> Result<(), 
                     description
                 )),
                 kind: crate::swagger20::SchemaKind::Ty(ty(optional_definition)),
-                kubernetes_group_kind_versions: None,
+                kubernetes_group_kind_versions: vec![],
                 has_corresponding_list_type: false,
             },
         );
@@ -234,10 +233,9 @@ pub(crate) fn remove_delete_collection_operations_query_parameters(
                         ),
                         kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                             path: "io.k8s.DeleteOptional".to_owned(),
-                            relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                             can_be_default: None,
                         }),
-                        kubernetes_group_kind_versions: None,
+                        kubernetes_group_kind_versions: vec![],
                         has_corresponding_list_type: false,
                     },
                 }));
@@ -253,10 +251,9 @@ pub(crate) fn remove_delete_collection_operations_query_parameters(
                         ),
                         kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                             path: "io.k8s.ListOptional".to_owned(),
-                            relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                             can_be_default: None,
                         }),
-                        kubernetes_group_kind_versions: None,
+                        kubernetes_group_kind_versions: vec![],
                         has_corresponding_list_type: false,
                     },
                 }));
@@ -305,10 +302,9 @@ pub(crate) fn remove_delete_operations_query_parameters(
 								description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
 								kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
 									path: "io.k8s.DeleteOptional".to_owned(),
-									relative_to: crate::swagger20::RefPathRelativeTo::Crate,
 									can_be_default: None,
 								}),
-								kubernetes_group_kind_versions: None,
+								kubernetes_group_kind_versions: vec![],
 								has_corresponding_list_type: false,
 							},
 						}));
@@ -443,7 +439,7 @@ pub(crate) fn separate_watch_from_list_operations(
             kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListOptional(
                 list_optional_definition,
             )),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     );
@@ -455,7 +451,7 @@ pub(crate) fn separate_watch_from_list_operations(
             kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::WatchOptional(
                 watch_optional_definition,
             )),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     );
@@ -470,10 +466,9 @@ pub(crate) fn separate_watch_from_list_operations(
             ),
             kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                 path: "io.k8s.ListOptional".to_owned(),
-                relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                 can_be_default: None,
             }),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     });
@@ -488,10 +483,9 @@ pub(crate) fn separate_watch_from_list_operations(
             ),
             kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                 path: "io.k8s.WatchOptional".to_owned(),
-                relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                 can_be_default: None,
             }),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     });
@@ -581,10 +575,9 @@ pub(crate) fn separate_watch_from_list_operations(
                     description: Some("OK".to_owned()),
                     kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
                         path: "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned(),
-                        relative_to: crate::swagger20::RefPathRelativeTo::Crate,
                         can_be_default: None,
                     }),
-                    kubernetes_group_kind_versions: None,
+                    kubernetes_group_kind_versions: vec![],
                     has_corresponding_list_type: false,
                 },
             );
@@ -616,7 +609,6 @@ pub(crate) fn separate_watch_from_list_operations(
 // Annotate the `WatchEvent` type as `swagger20::Type::WatchEvent` for special codegen.
 pub(crate) fn watch_event(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
     use std::fmt::Write;
-
     let definition_path = crate::swagger20::DefinitionPath(
         "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned(),
     );
@@ -643,7 +635,6 @@ pub(crate) fn watch_event(spec: &mut crate::swagger20::Spec) -> Result<(), crate
             }
         }
     }
-
     Err("never applied WatchEvent override".into())
 }
 
@@ -719,27 +710,18 @@ pub(crate) fn list(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error
 					spec.definitions.get(&crate::swagger20::DefinitionPath(item_ref_path.path.clone()))
 					.ok_or_else(|| format!("definition {} looks like a list but its item's definition does not exist in the spec", definition_path))?;
 
-            let item_kubernetes_group_kind_version = {
-                let item_kubernetes_group_kind_versions =
-						item_schema.kubernetes_group_kind_versions.as_ref()
-						.ok_or_else(|| format!("definition {} looks like a list but its item's definition does not have a group-version-kind", definition_path))?;
-                if item_kubernetes_group_kind_versions.len() != 1 {
-                    eprintln!("{:?}", item_kubernetes_group_kind_versions);
-                    return Err(format!("definition {} looks like a list but its item's definition does not have a single group-version-kind", definition_path).into());
-                }
-                &item_kubernetes_group_kind_versions[0]
+            let item_kubernetes_group_kind_version = match &item_schema.kubernetes_group_kind_versions[..] {
+                [group_kind_version] => group_kind_version,
+                _ => return Err(format!(
+                    "definition {} looks like a list but its item's definition does not have a single group-version-kind",
+                    definition_path).into()),
             };
 
-            let list_kubernetes_group_kind_version = {
-                let list_kubernetes_group_kind_versions =
-						definition.kubernetes_group_kind_versions.as_ref()
-						.ok_or_else(|| format!("definition {} looks like a list but it does not have a group-version-kind", definition_path))?;
-                if list_kubernetes_group_kind_versions.len() != 1 {
-                    eprintln!("{:?}", list_kubernetes_group_kind_versions);
-                    return Err(format!("definition {} looks like a list but it does not have a single group-version-kind", definition_path).into());
-                }
-
-                &list_kubernetes_group_kind_versions[0]
+            let list_kubernetes_group_kind_version = match &definition.kubernetes_group_kind_versions[..] {
+                [group_kind_version] => group_kind_version,
+                _ => return Err(format!(
+                    "definition {} looks like a list but it does not have a single group-version-kind",
+                    definition_path).into()),
             };
 
             let item_gkv_corresponds_to_list_gkv = list_kubernetes_group_kind_version.group
@@ -783,15 +765,14 @@ pub(crate) fn list(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error
                                 kind: crate::swagger20::SchemaKind::Ref(
                                     crate::swagger20::RefPath {
                                         path: "T".to_owned(),
-                                        relative_to: crate::swagger20::RefPathRelativeTo::Scope,
                                         can_be_default: None,
                                     },
                                 ),
-                                kubernetes_group_kind_versions: None,
+                                kubernetes_group_kind_versions: vec![],
                                 has_corresponding_list_type: false,
                             }),
                         }),
-                        kubernetes_group_kind_versions: None,
+                        kubernetes_group_kind_versions: vec![],
                         has_corresponding_list_type: false,
                     },
                     true,
@@ -816,7 +797,7 @@ pub(crate) fn list(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error
             kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListDef {
                 metadata: Box::new(metadata_schema_kind),
             }),
-            kubernetes_group_kind_versions: None,
+            kubernetes_group_kind_versions: vec![],
             has_corresponding_list_type: false,
         },
     );
@@ -1026,14 +1007,11 @@ pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), cr
                                                     operation.id, kubernetes_group_kind_version
                                                 )
                                             });
-                                        if let Some(kubernetes_group_kind_versions) =
-                                            &response_schema.kubernetes_group_kind_versions
+                                        if response_schema
+                                            .kubernetes_group_kind_versions
+                                            .contains(kubernetes_group_kind_version)
                                         {
-                                            if kubernetes_group_kind_versions
-                                                .contains(kubernetes_group_kind_version)
-                                            {
-                                                return true;
-                                            }
+                                            return true;
                                         }
                                     }
 
@@ -1343,7 +1321,7 @@ pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), cr
             crate::swagger20::Schema {
                 description: Some(description.to_owned()),
                 kind: crate::swagger20::SchemaKind::Ty(ty),
-                kubernetes_group_kind_versions: None,
+                kubernetes_group_kind_versions: vec![],
                 has_corresponding_list_type: false,
             },
         );
@@ -1354,7 +1332,9 @@ pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), cr
 
 // The `metadata` property of resource types is generally not optional, so override the property to be required.
 // For situations like PATCH requests where the property *is* optional, sending an empty object works the same.
-pub(crate) fn resource_metadata_not_optional(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+pub(crate) fn resource_metadata_not_optional(
+    spec: &mut crate::swagger20::Spec,
+) -> Result<(), crate::Error> {
     let mut found = false;
 
     for definition in spec.definitions.values_mut() {
@@ -1366,14 +1346,17 @@ pub(crate) fn resource_metadata_not_optional(spec: &mut crate::swagger20::Spec) 
             for (name, (_, required)) in &mut *properties {
                 has_api_version = has_api_version || name.0 == "apiVersion";
                 has_kind = has_kind || name.0 == "kind";
-                has_optional_metadata = has_optional_metadata || (name.0 == "metadata" && !*required);
+                has_optional_metadata =
+                    has_optional_metadata || (name.0 == "metadata" && !*required);
                 if has_api_version && has_kind && has_optional_metadata {
                     break;
                 }
             }
 
             if has_api_version && has_kind && has_optional_metadata {
-                let metadata = properties.get_mut(&crate::swagger20::PropertyName("metadata".to_owned())).unwrap();
+                let metadata = properties
+                    .get_mut(&crate::swagger20::PropertyName("metadata".to_owned()))
+                    .unwrap();
                 metadata.1 = true;
                 found = true;
             }
@@ -1382,8 +1365,7 @@ pub(crate) fn resource_metadata_not_optional(spec: &mut crate::swagger20::Spec) 
 
     if found {
         Ok(())
-    }
-    else {
+    } else {
         Err("never applied override to make resource metadata non-optional".into())
     }
 }

--- a/openshift-openapi-codegen/src/logger.rs
+++ b/openshift-openapi-codegen/src/logger.rs
@@ -2,15 +2,16 @@ pub(crate) struct Logger;
 
 impl log::Log for Logger {
     fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        THREAD_LOCAL_LOGGER.with(|thread_local_logger| thread_local_logger.borrow().as_ref().unwrap().enabled(metadata))
+        THREAD_LOCAL_LOGGER.with(|thread_local_logger|
+            if let Some(logger) = thread_local_logger.borrow().as_ref() { logger.enabled(metadata) } else { false })
     }
 
     fn log(&self, record: &log::Record<'_>) {
-        THREAD_LOCAL_LOGGER.with(|thread_local_logger| thread_local_logger.borrow().as_ref().unwrap().log(record))
+        THREAD_LOCAL_LOGGER.with(|thread_local_logger| if let Some(logger) = thread_local_logger.borrow().as_ref() { logger.log(record); })
     }
 
     fn flush(&self) {
-        THREAD_LOCAL_LOGGER.with(|thread_local_logger| thread_local_logger.borrow().as_ref().unwrap().flush())
+        THREAD_LOCAL_LOGGER.with(|thread_local_logger| if let Some(logger) = thread_local_logger.borrow().as_ref() { logger.flush(); })
     }
 }
 

--- a/openshift-openapi-codegen/src/supported_version.rs
+++ b/openshift-openapi-codegen/src/supported_version.rs
@@ -48,6 +48,7 @@ impl SupportedVersion {
             crate::fixups::special::watch_event,
             crate::fixups::special::list, // Must run after separate_watch_from_list_operations
             crate::fixups::special::response_types,
+            crate::fixups::special::resource_metadata_not_optional,
         ];
 
         for fixup in upstream_bugs_fixups.iter().chain(special_fixups) {

--- a/src/v4_3/api/apps/v1/deployment_config.rs
+++ b/src/v4_3/api/apps/v1/deployment_config.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DeploymentConfig {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec represents a desired deployment state and how to deploy to it.
     pub spec: crate::api::apps::v1::DeploymentConfigSpec,
@@ -696,8 +696,12 @@ impl k8s_openapi::ListableResource for DeploymentConfig {
 impl k8s_openapi::Metadata for DeploymentConfig {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -768,7 +772,7 @@ impl<'de> serde::Deserialize<'de> for DeploymentConfig {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -776,7 +780,7 @@ impl<'de> serde::Deserialize<'de> for DeploymentConfig {
                 }
 
                 Ok(DeploymentConfig {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status,
                 })
@@ -801,15 +805,12 @@ impl serde::Serialize for DeploymentConfig {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            4 +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         if let Some(value) = &self.status {
             serde::ser::SerializeStruct::serialize_field(&mut state, "status", value)?;

--- a/src/v4_3/api/authorization/v1/cluster_role_binding.rs
+++ b/src/v4_3/api/authorization/v1/cluster_role_binding.rs
@@ -7,7 +7,7 @@ pub struct ClusterRoleBinding {
     pub group_names: Vec<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// RoleRef can only reference the current namespace and the global namespace. If the ClusterRoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.
     pub role_ref: k8s_openapi::api::core::v1::ObjectReference,
@@ -344,8 +344,12 @@ impl k8s_openapi::ListableResource for ClusterRoleBinding {
 impl k8s_openapi::Metadata for ClusterRoleBinding {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -423,7 +427,7 @@ impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {
                             }
                         },
                         Field::Key_group_names => value_group_names = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_role_ref => value_role_ref = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_subjects => value_subjects = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user_names => value_user_names = Some(serde::de::MapAccess::next_value(&mut map)?),
@@ -433,7 +437,7 @@ impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {
 
                 Ok(ClusterRoleBinding {
                     group_names: value_group_names.ok_or_else(|| serde::de::Error::missing_field("groupNames"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     role_ref: value_role_ref.ok_or_else(|| serde::de::Error::missing_field("roleRef"))?,
                     subjects: value_subjects.ok_or_else(|| serde::de::Error::missing_field("subjects"))?,
                     user_names: value_user_names.ok_or_else(|| serde::de::Error::missing_field("userNames"))?,
@@ -461,15 +465,12 @@ impl serde::Serialize for ClusterRoleBinding {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "groupNames", &self.group_names)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "roleRef", &self.role_ref)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "subjects", &self.subjects)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "userNames", &self.user_names)?;

--- a/src/v4_3/api/authorization/v1/role.rs
+++ b/src/v4_3/api/authorization/v1/role.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Role {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Rules holds all the PolicyRules for this Role
     pub rules: Vec<crate::api::authorization::v1::PolicyRule>,
@@ -444,8 +444,12 @@ impl k8s_openapi::ListableResource for Role {
 impl k8s_openapi::Metadata for Role {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -513,14 +517,14 @@ impl<'de> serde::Deserialize<'de> for Role {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_rules => value_rules = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(Role {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     rules: value_rules.ok_or_else(|| serde::de::Error::missing_field("rules"))?,
                 })
             }
@@ -543,14 +547,11 @@ impl serde::Serialize for Role {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "rules", &self.rules)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_3/api/authorization/v1/role_binding.rs
+++ b/src/v4_3/api/authorization/v1/role_binding.rs
@@ -7,7 +7,7 @@ pub struct RoleBinding {
     pub group_names: Vec<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// RoleRef can only reference the current namespace and the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.
     pub role_ref: k8s_openapi::api::core::v1::ObjectReference,
@@ -453,8 +453,12 @@ impl k8s_openapi::ListableResource for RoleBinding {
 impl k8s_openapi::Metadata for RoleBinding {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -532,7 +536,7 @@ impl<'de> serde::Deserialize<'de> for RoleBinding {
                             }
                         },
                         Field::Key_group_names => value_group_names = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_role_ref => value_role_ref = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_subjects => value_subjects = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user_names => value_user_names = Some(serde::de::MapAccess::next_value(&mut map)?),
@@ -542,7 +546,7 @@ impl<'de> serde::Deserialize<'de> for RoleBinding {
 
                 Ok(RoleBinding {
                     group_names: value_group_names.ok_or_else(|| serde::de::Error::missing_field("groupNames"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     role_ref: value_role_ref.ok_or_else(|| serde::de::Error::missing_field("roleRef"))?,
                     subjects: value_subjects.ok_or_else(|| serde::de::Error::missing_field("subjects"))?,
                     user_names: value_user_names.ok_or_else(|| serde::de::Error::missing_field("userNames"))?,
@@ -570,15 +574,12 @@ impl serde::Serialize for RoleBinding {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "groupNames", &self.group_names)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "roleRef", &self.role_ref)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "subjects", &self.subjects)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "userNames", &self.user_names)?;

--- a/src/v4_3/api/authorization/v1/role_binding_restriction.rs
+++ b/src/v4_3/api/authorization/v1/role_binding_restriction.rs
@@ -499,8 +499,12 @@ impl k8s_openapi::ListableResource for RoleBindingRestriction {
 impl k8s_openapi::Metadata for RoleBindingRestriction {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_3/api/build/v1/build.rs
+++ b/src/v4_3/api/build/v1/build.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Build {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec is all the inputs used to execute the build.
     pub spec: Option<crate::api::build::v1::BuildSpec>,
@@ -744,8 +744,12 @@ impl k8s_openapi::ListableResource for Build {
 impl k8s_openapi::Metadata for Build {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -816,7 +820,7 @@ impl<'de> serde::Deserialize<'de> for Build {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -824,7 +828,7 @@ impl<'de> serde::Deserialize<'de> for Build {
                 }
 
                 Ok(Build {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec,
                     status: value_status,
                 })
@@ -849,16 +853,13 @@ impl serde::Serialize for Build {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            3 +
             self.spec.as_ref().map_or(0, |_| 1) +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.spec {
             serde::ser::SerializeStruct::serialize_field(&mut state, "spec", value)?;
         }

--- a/src/v4_3/api/build/v1/build_config.rs
+++ b/src/v4_3/api/build/v1/build_config.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct BuildConfig {
     /// metadata for BuildConfig.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec holds all the input necessary to produce a new build, and the conditions when to trigger them.
     pub spec: crate::api::build::v1::BuildConfigSpec,
@@ -504,8 +504,12 @@ impl k8s_openapi::ListableResource for BuildConfig {
 impl k8s_openapi::Metadata for BuildConfig {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -576,7 +580,7 @@ impl<'de> serde::Deserialize<'de> for BuildConfig {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -584,7 +588,7 @@ impl<'de> serde::Deserialize<'de> for BuildConfig {
                 }
 
                 Ok(BuildConfig {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -609,14 +613,11 @@ impl serde::Serialize for BuildConfig {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_3/api/image/v1/image_stream.rs
+++ b/src/v4_3/api/image/v1/image_stream.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ImageStream {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec describes the desired state of this stream
     pub spec: crate::api::image::v1::ImageStreamSpec,
@@ -694,8 +694,12 @@ impl k8s_openapi::ListableResource for ImageStream {
 impl k8s_openapi::Metadata for ImageStream {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -766,7 +770,7 @@ impl<'de> serde::Deserialize<'de> for ImageStream {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -774,7 +778,7 @@ impl<'de> serde::Deserialize<'de> for ImageStream {
                 }
 
                 Ok(ImageStream {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status,
                 })
@@ -799,15 +803,12 @@ impl serde::Serialize for ImageStream {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            4 +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         if let Some(value) = &self.status {
             serde::ser::SerializeStruct::serialize_field(&mut state, "status", value)?;

--- a/src/v4_3/api/image/v1/image_stream_image.rs
+++ b/src/v4_3/api/image/v1/image_stream_image.rs
@@ -7,7 +7,7 @@ pub struct ImageStreamImage {
     pub image: crate::api::image::v1::Image,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 }
 
 // Begin image.openshift.io/v1/ImageStreamImage
@@ -118,8 +118,12 @@ impl k8s_openapi::Resource for ImageStreamImage {
 impl k8s_openapi::Metadata for ImageStreamImage {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -188,14 +192,14 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImage {
                             }
                         },
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(ImageStreamImage {
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                 })
             }
         }
@@ -217,15 +221,12 @@ impl serde::Serialize for ImageStreamImage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::end(state)
     }
 }

--- a/src/v4_3/api/image/v1/image_stream_import.rs
+++ b/src/v4_3/api/image/v1/image_stream_import.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ImageStreamImport {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec is a description of the images that the user wishes to import
     pub spec: crate::api::image::v1::ImageStreamImportSpec,
@@ -70,8 +70,12 @@ impl k8s_openapi::Resource for ImageStreamImport {
 impl k8s_openapi::Metadata for ImageStreamImport {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -142,7 +146,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImport {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -150,7 +154,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImport {
                 }
 
                 Ok(ImageStreamImport {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -175,14 +179,11 @@ impl serde::Serialize for ImageStreamImport {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_3/api/image/v1/image_stream_layers.rs
+++ b/src/v4_3/api/image/v1/image_stream_layers.rs
@@ -10,7 +10,7 @@ pub struct ImageStreamLayers {
     pub images: std::collections::BTreeMap<String, crate::api::image::v1::ImageBlobReferences>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 }
 
 // Begin image.openshift.io/v1/ImageStreamLayers
@@ -121,8 +121,12 @@ impl k8s_openapi::Resource for ImageStreamLayers {
 impl k8s_openapi::Metadata for ImageStreamLayers {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -195,7 +199,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamLayers {
                         },
                         Field::Key_blobs => value_blobs = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_images => value_images = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
@@ -203,7 +207,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamLayers {
                 Ok(ImageStreamLayers {
                     blobs: value_blobs.ok_or_else(|| serde::de::Error::missing_field("blobs"))?,
                     images: value_images.ok_or_else(|| serde::de::Error::missing_field("images"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                 })
             }
         }
@@ -226,16 +230,13 @@ impl serde::Serialize for ImageStreamLayers {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "blobs", &self.blobs)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "images", &self.images)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::end(state)
     }
 }

--- a/src/v4_3/api/image/v1/image_stream_mapping.rs
+++ b/src/v4_3/api/image/v1/image_stream_mapping.rs
@@ -7,7 +7,7 @@ pub struct ImageStreamMapping {
     pub image: crate::api::image::v1::Image,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Tag is a string value this image can be located with inside the stream.
     pub tag: String,
@@ -68,8 +68,12 @@ impl k8s_openapi::Resource for ImageStreamMapping {
 impl k8s_openapi::Metadata for ImageStreamMapping {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -141,7 +145,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamMapping {
                             }
                         },
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_tag => value_tag = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -149,7 +153,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamMapping {
 
                 Ok(ImageStreamMapping {
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     tag: value_tag.ok_or_else(|| serde::de::Error::missing_field("tag"))?,
                 })
             }
@@ -173,15 +177,12 @@ impl serde::Serialize for ImageStreamMapping {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "tag", &self.tag)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_3/api/image/v1/image_stream_tag.rs
+++ b/src/v4_3/api/image/v1/image_stream_tag.rs
@@ -16,7 +16,7 @@ pub struct ImageStreamTag {
     pub lookup_policy: crate::api::image::v1::ImageLookupPolicy,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.
     pub tag: crate::api::image::v1::TagReference,
@@ -456,8 +456,12 @@ impl k8s_openapi::ListableResource for ImageStreamTag {
 impl k8s_openapi::Metadata for ImageStreamTag {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -541,7 +545,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamTag {
                         Field::Key_generation => value_generation = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_lookup_policy => value_lookup_policy = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_tag => value_tag = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -552,7 +556,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamTag {
                     generation: value_generation.ok_or_else(|| serde::de::Error::missing_field("generation"))?,
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
                     lookup_policy: value_lookup_policy.ok_or_else(|| serde::de::Error::missing_field("lookupPolicy"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     tag: value_tag.ok_or_else(|| serde::de::Error::missing_field("tag"))?,
                 })
             }
@@ -579,9 +583,8 @@ impl serde::Serialize for ImageStreamTag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.conditions.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7 +
+            self.conditions.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
@@ -591,9 +594,7 @@ impl serde::Serialize for ImageStreamTag {
         serde::ser::SerializeStruct::serialize_field(&mut state, "generation", &self.generation)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "lookupPolicy", &self.lookup_policy)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "tag", &self.tag)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_3/api/network/v1/egress_network_policy.rs
+++ b/src/v4_3/api/network/v1/egress_network_policy.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct EgressNetworkPolicy {
     /// metadata for EgressNetworkPolicy
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec is the specification of the current egress network policy
     pub spec: crate::api::network::v1::EgressNetworkPolicySpec,
@@ -499,8 +499,12 @@ impl k8s_openapi::ListableResource for EgressNetworkPolicy {
 impl k8s_openapi::Metadata for EgressNetworkPolicy {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -568,14 +572,14 @@ impl<'de> serde::Deserialize<'de> for EgressNetworkPolicy {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(EgressNetworkPolicy {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                 })
             }
@@ -598,14 +602,11 @@ impl serde::Serialize for EgressNetworkPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_3/api/oauth/v1/o_auth_client_authorization.rs
+++ b/src/v4_3/api/oauth/v1/o_auth_client_authorization.rs
@@ -7,7 +7,7 @@ pub struct OAuthClientAuthorization {
     pub client_name: Option<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Scopes is an array of the granted scopes.
     pub scopes: Option<Vec<String>>,
@@ -392,8 +392,12 @@ impl k8s_openapi::ListableResource for OAuthClientAuthorization {
 impl k8s_openapi::Metadata for OAuthClientAuthorization {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -471,7 +475,7 @@ impl<'de> serde::Deserialize<'de> for OAuthClientAuthorization {
                             }
                         },
                         Field::Key_client_name => value_client_name = serde::de::MapAccess::next_value(&mut map)?,
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_scopes => value_scopes = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_user_name => value_user_name = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_user_uid => value_user_uid = serde::de::MapAccess::next_value(&mut map)?,
@@ -481,7 +485,7 @@ impl<'de> serde::Deserialize<'de> for OAuthClientAuthorization {
 
                 Ok(OAuthClientAuthorization {
                     client_name: value_client_name,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     scopes: value_scopes,
                     user_name: value_user_name,
                     user_uid: value_user_uid,
@@ -509,9 +513,8 @@ impl serde::Serialize for OAuthClientAuthorization {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
+            3 +
             self.client_name.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1) +
             self.scopes.as_ref().map_or(0, |_| 1) +
             self.user_name.as_ref().map_or(0, |_| 1) +
             self.user_uid.as_ref().map_or(0, |_| 1),
@@ -521,9 +524,7 @@ impl serde::Serialize for OAuthClientAuthorization {
         if let Some(value) = &self.client_name {
             serde::ser::SerializeStruct::serialize_field(&mut state, "clientName", value)?;
         }
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.scopes {
             serde::ser::SerializeStruct::serialize_field(&mut state, "scopes", value)?;
         }

--- a/src/v4_3/api/quota/v1/applied_cluster_resource_quota.rs
+++ b/src/v4_3/api/quota/v1/applied_cluster_resource_quota.rs
@@ -267,8 +267,12 @@ impl k8s_openapi::ListableResource for AppliedClusterResourceQuota {
 impl k8s_openapi::Metadata for AppliedClusterResourceQuota {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_3/api/quota/v1/cluster_resource_quota.rs
+++ b/src/v4_3/api/quota/v1/cluster_resource_quota.rs
@@ -560,8 +560,12 @@ impl k8s_openapi::ListableResource for ClusterResourceQuota {
 impl k8s_openapi::Metadata for ClusterResourceQuota {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_3/api/template/v1/template_instance.rs
+++ b/src/v4_3/api/template/v1/template_instance.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TemplateInstance {
     /// Standard object metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec describes the desired state of this TemplateInstance.
     pub spec: crate::api::template::v1::TemplateInstanceSpec,
@@ -694,8 +694,12 @@ impl k8s_openapi::ListableResource for TemplateInstance {
 impl k8s_openapi::Metadata for TemplateInstance {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -766,7 +770,7 @@ impl<'de> serde::Deserialize<'de> for TemplateInstance {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -774,7 +778,7 @@ impl<'de> serde::Deserialize<'de> for TemplateInstance {
                 }
 
                 Ok(TemplateInstance {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -799,14 +803,11 @@ impl serde::Serialize for TemplateInstance {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_3/api/user/v1/group.rs
+++ b/src/v4_3/api/user/v1/group.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Group {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Users is the list of users in this group.
     pub users: Vec<String>,
@@ -383,8 +383,12 @@ impl k8s_openapi::ListableResource for Group {
 impl k8s_openapi::Metadata for Group {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -452,14 +456,14 @@ impl<'de> serde::Deserialize<'de> for Group {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_users => value_users = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(Group {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     users: value_users.ok_or_else(|| serde::de::Error::missing_field("users"))?,
                 })
             }
@@ -482,14 +486,11 @@ impl serde::Serialize for Group {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "users", &self.users)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_3/api/user/v1/user_identity_mapping.rs
+++ b/src/v4_3/api/user/v1/user_identity_mapping.rs
@@ -7,7 +7,7 @@ pub struct UserIdentityMapping {
     pub identity: Option<k8s_openapi::api::core::v1::ObjectReference>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// User is a reference to a user
     pub user: Option<k8s_openapi::api::core::v1::ObjectReference>,
@@ -270,8 +270,12 @@ impl k8s_openapi::Resource for UserIdentityMapping {
 impl k8s_openapi::Metadata for UserIdentityMapping {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -343,7 +347,7 @@ impl<'de> serde::Deserialize<'de> for UserIdentityMapping {
                             }
                         },
                         Field::Key_identity => value_identity = serde::de::MapAccess::next_value(&mut map)?,
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user => value_user = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -351,7 +355,7 @@ impl<'de> serde::Deserialize<'de> for UserIdentityMapping {
 
                 Ok(UserIdentityMapping {
                     identity: value_identity,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     user: value_user,
                 })
             }
@@ -375,9 +379,8 @@ impl serde::Serialize for UserIdentityMapping {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
+            3 +
             self.identity.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1) +
             self.user.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
@@ -385,9 +388,7 @@ impl serde::Serialize for UserIdentityMapping {
         if let Some(value) = &self.identity {
             serde::ser::SerializeStruct::serialize_field(&mut state, "identity", value)?;
         }
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.user {
             serde::ser::SerializeStruct::serialize_field(&mut state, "user", value)?;
         }

--- a/src/v4_4/api/apps/v1/deployment_config.rs
+++ b/src/v4_4/api/apps/v1/deployment_config.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DeploymentConfig {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec represents a desired deployment state and how to deploy to it.
     pub spec: crate::api::apps::v1::DeploymentConfigSpec,
@@ -696,8 +696,12 @@ impl k8s_openapi::ListableResource for DeploymentConfig {
 impl k8s_openapi::Metadata for DeploymentConfig {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -768,7 +772,7 @@ impl<'de> serde::Deserialize<'de> for DeploymentConfig {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -776,7 +780,7 @@ impl<'de> serde::Deserialize<'de> for DeploymentConfig {
                 }
 
                 Ok(DeploymentConfig {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status,
                 })
@@ -801,15 +805,12 @@ impl serde::Serialize for DeploymentConfig {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            4 +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         if let Some(value) = &self.status {
             serde::ser::SerializeStruct::serialize_field(&mut state, "status", value)?;

--- a/src/v4_4/api/authorization/v1/cluster_role_binding.rs
+++ b/src/v4_4/api/authorization/v1/cluster_role_binding.rs
@@ -7,7 +7,7 @@ pub struct ClusterRoleBinding {
     pub group_names: Vec<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// RoleRef can only reference the current namespace and the global namespace. If the ClusterRoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.
     pub role_ref: k8s_openapi::api::core::v1::ObjectReference,
@@ -344,8 +344,12 @@ impl k8s_openapi::ListableResource for ClusterRoleBinding {
 impl k8s_openapi::Metadata for ClusterRoleBinding {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -423,7 +427,7 @@ impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {
                             }
                         },
                         Field::Key_group_names => value_group_names = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_role_ref => value_role_ref = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_subjects => value_subjects = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user_names => value_user_names = Some(serde::de::MapAccess::next_value(&mut map)?),
@@ -433,7 +437,7 @@ impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {
 
                 Ok(ClusterRoleBinding {
                     group_names: value_group_names.ok_or_else(|| serde::de::Error::missing_field("groupNames"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     role_ref: value_role_ref.ok_or_else(|| serde::de::Error::missing_field("roleRef"))?,
                     subjects: value_subjects.ok_or_else(|| serde::de::Error::missing_field("subjects"))?,
                     user_names: value_user_names.ok_or_else(|| serde::de::Error::missing_field("userNames"))?,
@@ -461,15 +465,12 @@ impl serde::Serialize for ClusterRoleBinding {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "groupNames", &self.group_names)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "roleRef", &self.role_ref)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "subjects", &self.subjects)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "userNames", &self.user_names)?;

--- a/src/v4_4/api/authorization/v1/role.rs
+++ b/src/v4_4/api/authorization/v1/role.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Role {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Rules holds all the PolicyRules for this Role
     pub rules: Vec<crate::api::authorization::v1::PolicyRule>,
@@ -444,8 +444,12 @@ impl k8s_openapi::ListableResource for Role {
 impl k8s_openapi::Metadata for Role {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -513,14 +517,14 @@ impl<'de> serde::Deserialize<'de> for Role {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_rules => value_rules = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(Role {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     rules: value_rules.ok_or_else(|| serde::de::Error::missing_field("rules"))?,
                 })
             }
@@ -543,14 +547,11 @@ impl serde::Serialize for Role {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "rules", &self.rules)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_4/api/authorization/v1/role_binding.rs
+++ b/src/v4_4/api/authorization/v1/role_binding.rs
@@ -7,7 +7,7 @@ pub struct RoleBinding {
     pub group_names: Vec<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// RoleRef can only reference the current namespace and the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.
     pub role_ref: k8s_openapi::api::core::v1::ObjectReference,
@@ -453,8 +453,12 @@ impl k8s_openapi::ListableResource for RoleBinding {
 impl k8s_openapi::Metadata for RoleBinding {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -532,7 +536,7 @@ impl<'de> serde::Deserialize<'de> for RoleBinding {
                             }
                         },
                         Field::Key_group_names => value_group_names = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_role_ref => value_role_ref = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_subjects => value_subjects = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user_names => value_user_names = Some(serde::de::MapAccess::next_value(&mut map)?),
@@ -542,7 +546,7 @@ impl<'de> serde::Deserialize<'de> for RoleBinding {
 
                 Ok(RoleBinding {
                     group_names: value_group_names.ok_or_else(|| serde::de::Error::missing_field("groupNames"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     role_ref: value_role_ref.ok_or_else(|| serde::de::Error::missing_field("roleRef"))?,
                     subjects: value_subjects.ok_or_else(|| serde::de::Error::missing_field("subjects"))?,
                     user_names: value_user_names.ok_or_else(|| serde::de::Error::missing_field("userNames"))?,
@@ -570,15 +574,12 @@ impl serde::Serialize for RoleBinding {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "groupNames", &self.group_names)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "roleRef", &self.role_ref)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "subjects", &self.subjects)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "userNames", &self.user_names)?;

--- a/src/v4_4/api/authorization/v1/role_binding_restriction.rs
+++ b/src/v4_4/api/authorization/v1/role_binding_restriction.rs
@@ -499,8 +499,12 @@ impl k8s_openapi::ListableResource for RoleBindingRestriction {
 impl k8s_openapi::Metadata for RoleBindingRestriction {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_4/api/build/v1/build.rs
+++ b/src/v4_4/api/build/v1/build.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Build {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec is all the inputs used to execute the build.
     pub spec: Option<crate::api::build::v1::BuildSpec>,
@@ -744,8 +744,12 @@ impl k8s_openapi::ListableResource for Build {
 impl k8s_openapi::Metadata for Build {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -816,7 +820,7 @@ impl<'de> serde::Deserialize<'de> for Build {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -824,7 +828,7 @@ impl<'de> serde::Deserialize<'de> for Build {
                 }
 
                 Ok(Build {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec,
                     status: value_status,
                 })
@@ -849,16 +853,13 @@ impl serde::Serialize for Build {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            3 +
             self.spec.as_ref().map_or(0, |_| 1) +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.spec {
             serde::ser::SerializeStruct::serialize_field(&mut state, "spec", value)?;
         }

--- a/src/v4_4/api/build/v1/build_config.rs
+++ b/src/v4_4/api/build/v1/build_config.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct BuildConfig {
     /// metadata for BuildConfig.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec holds all the input necessary to produce a new build, and the conditions when to trigger them.
     pub spec: crate::api::build::v1::BuildConfigSpec,
@@ -504,8 +504,12 @@ impl k8s_openapi::ListableResource for BuildConfig {
 impl k8s_openapi::Metadata for BuildConfig {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -576,7 +580,7 @@ impl<'de> serde::Deserialize<'de> for BuildConfig {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -584,7 +588,7 @@ impl<'de> serde::Deserialize<'de> for BuildConfig {
                 }
 
                 Ok(BuildConfig {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -609,14 +613,11 @@ impl serde::Serialize for BuildConfig {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_4/api/image/v1/image_stream.rs
+++ b/src/v4_4/api/image/v1/image_stream.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ImageStream {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec describes the desired state of this stream
     pub spec: crate::api::image::v1::ImageStreamSpec,
@@ -694,8 +694,12 @@ impl k8s_openapi::ListableResource for ImageStream {
 impl k8s_openapi::Metadata for ImageStream {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -766,7 +770,7 @@ impl<'de> serde::Deserialize<'de> for ImageStream {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -774,7 +778,7 @@ impl<'de> serde::Deserialize<'de> for ImageStream {
                 }
 
                 Ok(ImageStream {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status,
                 })
@@ -799,15 +803,12 @@ impl serde::Serialize for ImageStream {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1) +
+            4 +
             self.status.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         if let Some(value) = &self.status {
             serde::ser::SerializeStruct::serialize_field(&mut state, "status", value)?;

--- a/src/v4_4/api/image/v1/image_stream_image.rs
+++ b/src/v4_4/api/image/v1/image_stream_image.rs
@@ -7,7 +7,7 @@ pub struct ImageStreamImage {
     pub image: crate::api::image::v1::Image,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 }
 
 // Begin image.openshift.io/v1/ImageStreamImage
@@ -118,8 +118,12 @@ impl k8s_openapi::Resource for ImageStreamImage {
 impl k8s_openapi::Metadata for ImageStreamImage {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -188,14 +192,14 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImage {
                             }
                         },
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(ImageStreamImage {
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                 })
             }
         }
@@ -217,15 +221,12 @@ impl serde::Serialize for ImageStreamImage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::end(state)
     }
 }

--- a/src/v4_4/api/image/v1/image_stream_import.rs
+++ b/src/v4_4/api/image/v1/image_stream_import.rs
@@ -6,7 +6,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ImageStreamImport {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Spec is a description of the images that the user wishes to import
     pub spec: crate::api::image::v1::ImageStreamImportSpec,
@@ -70,8 +70,12 @@ impl k8s_openapi::Resource for ImageStreamImport {
 impl k8s_openapi::Metadata for ImageStreamImport {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -142,7 +146,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImport {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -150,7 +154,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamImport {
                 }
 
                 Ok(ImageStreamImport {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -175,14 +179,11 @@ impl serde::Serialize for ImageStreamImport {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_4/api/image/v1/image_stream_layers.rs
+++ b/src/v4_4/api/image/v1/image_stream_layers.rs
@@ -10,7 +10,7 @@ pub struct ImageStreamLayers {
     pub images: std::collections::BTreeMap<String, crate::api::image::v1::ImageBlobReferences>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 }
 
 // Begin image.openshift.io/v1/ImageStreamLayers
@@ -121,8 +121,12 @@ impl k8s_openapi::Resource for ImageStreamLayers {
 impl k8s_openapi::Metadata for ImageStreamLayers {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -195,7 +199,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamLayers {
                         },
                         Field::Key_blobs => value_blobs = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_images => value_images = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
@@ -203,7 +207,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamLayers {
                 Ok(ImageStreamLayers {
                     blobs: value_blobs.ok_or_else(|| serde::de::Error::missing_field("blobs"))?,
                     images: value_images.ok_or_else(|| serde::de::Error::missing_field("images"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                 })
             }
         }
@@ -226,16 +230,13 @@ impl serde::Serialize for ImageStreamLayers {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "blobs", &self.blobs)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "images", &self.images)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::end(state)
     }
 }

--- a/src/v4_4/api/image/v1/image_stream_mapping.rs
+++ b/src/v4_4/api/image/v1/image_stream_mapping.rs
@@ -7,7 +7,7 @@ pub struct ImageStreamMapping {
     pub image: crate::api::image::v1::Image,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Tag is a string value this image can be located with inside the stream.
     pub tag: String,
@@ -68,8 +68,12 @@ impl k8s_openapi::Resource for ImageStreamMapping {
 impl k8s_openapi::Metadata for ImageStreamMapping {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -141,7 +145,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamMapping {
                             }
                         },
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_tag => value_tag = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -149,7 +153,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamMapping {
 
                 Ok(ImageStreamMapping {
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     tag: value_tag.ok_or_else(|| serde::de::Error::missing_field("tag"))?,
                 })
             }
@@ -173,15 +177,12 @@ impl serde::Serialize for ImageStreamMapping {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "tag", &self.tag)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_4/api/image/v1/image_stream_tag.rs
+++ b/src/v4_4/api/image/v1/image_stream_tag.rs
@@ -16,7 +16,7 @@ pub struct ImageStreamTag {
     pub lookup_policy: crate::api::image::v1::ImageLookupPolicy,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.
     pub tag: crate::api::image::v1::TagReference,
@@ -456,8 +456,12 @@ impl k8s_openapi::ListableResource for ImageStreamTag {
 impl k8s_openapi::Metadata for ImageStreamTag {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -541,7 +545,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamTag {
                         Field::Key_generation => value_generation = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_image => value_image = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_lookup_policy => value_lookup_policy = Some(serde::de::MapAccess::next_value(&mut map)?),
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_tag => value_tag = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -552,7 +556,7 @@ impl<'de> serde::Deserialize<'de> for ImageStreamTag {
                     generation: value_generation.ok_or_else(|| serde::de::Error::missing_field("generation"))?,
                     image: value_image.ok_or_else(|| serde::de::Error::missing_field("image"))?,
                     lookup_policy: value_lookup_policy.ok_or_else(|| serde::de::Error::missing_field("lookupPolicy"))?,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     tag: value_tag.ok_or_else(|| serde::de::Error::missing_field("tag"))?,
                 })
             }
@@ -579,9 +583,8 @@ impl serde::Serialize for ImageStreamTag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            6 +
-            self.conditions.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            7 +
+            self.conditions.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
@@ -591,9 +594,7 @@ impl serde::Serialize for ImageStreamTag {
         serde::ser::SerializeStruct::serialize_field(&mut state, "generation", &self.generation)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "image", &self.image)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "lookupPolicy", &self.lookup_policy)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "tag", &self.tag)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_4/api/network/v1/egress_network_policy.rs
+++ b/src/v4_4/api/network/v1/egress_network_policy.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct EgressNetworkPolicy {
     /// metadata for EgressNetworkPolicy
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec is the specification of the current egress network policy
     pub spec: crate::api::network::v1::EgressNetworkPolicySpec,
@@ -499,8 +499,12 @@ impl k8s_openapi::ListableResource for EgressNetworkPolicy {
 impl k8s_openapi::Metadata for EgressNetworkPolicy {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -568,14 +572,14 @@ impl<'de> serde::Deserialize<'de> for EgressNetworkPolicy {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(EgressNetworkPolicy {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                 })
             }
@@ -598,14 +602,11 @@ impl serde::Serialize for EgressNetworkPolicy {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_4/api/oauth/v1/o_auth_client_authorization.rs
+++ b/src/v4_4/api/oauth/v1/o_auth_client_authorization.rs
@@ -7,7 +7,7 @@ pub struct OAuthClientAuthorization {
     pub client_name: Option<String>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Scopes is an array of the granted scopes.
     pub scopes: Option<Vec<String>>,
@@ -392,8 +392,12 @@ impl k8s_openapi::ListableResource for OAuthClientAuthorization {
 impl k8s_openapi::Metadata for OAuthClientAuthorization {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -471,7 +475,7 @@ impl<'de> serde::Deserialize<'de> for OAuthClientAuthorization {
                             }
                         },
                         Field::Key_client_name => value_client_name = serde::de::MapAccess::next_value(&mut map)?,
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_scopes => value_scopes = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_user_name => value_user_name = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Key_user_uid => value_user_uid = serde::de::MapAccess::next_value(&mut map)?,
@@ -481,7 +485,7 @@ impl<'de> serde::Deserialize<'de> for OAuthClientAuthorization {
 
                 Ok(OAuthClientAuthorization {
                     client_name: value_client_name,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     scopes: value_scopes,
                     user_name: value_user_name,
                     user_uid: value_user_uid,
@@ -509,9 +513,8 @@ impl serde::Serialize for OAuthClientAuthorization {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
+            3 +
             self.client_name.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1) +
             self.scopes.as_ref().map_or(0, |_| 1) +
             self.user_name.as_ref().map_or(0, |_| 1) +
             self.user_uid.as_ref().map_or(0, |_| 1),
@@ -521,9 +524,7 @@ impl serde::Serialize for OAuthClientAuthorization {
         if let Some(value) = &self.client_name {
             serde::ser::SerializeStruct::serialize_field(&mut state, "clientName", value)?;
         }
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.scopes {
             serde::ser::SerializeStruct::serialize_field(&mut state, "scopes", value)?;
         }

--- a/src/v4_4/api/quota/v1/applied_cluster_resource_quota.rs
+++ b/src/v4_4/api/quota/v1/applied_cluster_resource_quota.rs
@@ -267,8 +267,12 @@ impl k8s_openapi::ListableResource for AppliedClusterResourceQuota {
 impl k8s_openapi::Metadata for AppliedClusterResourceQuota {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_4/api/quota/v1/cluster_resource_quota.rs
+++ b/src/v4_4/api/quota/v1/cluster_resource_quota.rs
@@ -560,8 +560,12 @@ impl k8s_openapi::ListableResource for ClusterResourceQuota {
 impl k8s_openapi::Metadata for ClusterResourceQuota {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        Some(&self.metadata)
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 

--- a/src/v4_4/api/template/v1/template_instance.rs
+++ b/src/v4_4/api/template/v1/template_instance.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TemplateInstance {
     /// Standard object metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// spec describes the desired state of this TemplateInstance.
     pub spec: crate::api::template::v1::TemplateInstanceSpec,
@@ -694,8 +694,12 @@ impl k8s_openapi::ListableResource for TemplateInstance {
 impl k8s_openapi::Metadata for TemplateInstance {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -766,7 +770,7 @@ impl<'de> serde::Deserialize<'de> for TemplateInstance {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_spec => value_spec = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_status => value_status = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
@@ -774,7 +778,7 @@ impl<'de> serde::Deserialize<'de> for TemplateInstance {
                 }
 
                 Ok(TemplateInstance {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     spec: value_spec.ok_or_else(|| serde::de::Error::missing_field("spec"))?,
                     status: value_status.ok_or_else(|| serde::de::Error::missing_field("status"))?,
                 })
@@ -799,14 +803,11 @@ impl serde::Serialize for TemplateInstance {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            4 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            5,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "spec", &self.spec)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "status", &self.status)?;
         serde::ser::SerializeStruct::end(state)

--- a/src/v4_4/api/user/v1/group.rs
+++ b/src/v4_4/api/user/v1/group.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Group {
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// Users is the list of users in this group.
     pub users: Vec<String>,
@@ -383,8 +383,12 @@ impl k8s_openapi::ListableResource for Group {
 impl k8s_openapi::Metadata for Group {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -452,14 +456,14 @@ impl<'de> serde::Deserialize<'de> for Group {
                                 return Err(serde::de::Error::invalid_value(serde::de::Unexpected::Str(&value_kind), &<Self::Value as k8s_openapi::Resource>::KIND));
                             }
                         },
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_users => value_users = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
                 }
 
                 Ok(Group {
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     users: value_users.ok_or_else(|| serde::de::Error::missing_field("users"))?,
                 })
             }
@@ -482,14 +486,11 @@ impl serde::Serialize for Group {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            3 +
-            self.metadata.as_ref().map_or(0, |_| 1),
+            4,
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "kind", <Self as k8s_openapi::Resource>::KIND)?;
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "users", &self.users)?;
         serde::ser::SerializeStruct::end(state)
     }

--- a/src/v4_4/api/user/v1/user_identity_mapping.rs
+++ b/src/v4_4/api/user/v1/user_identity_mapping.rs
@@ -7,7 +7,7 @@ pub struct UserIdentityMapping {
     pub identity: Option<k8s_openapi::api::core::v1::ObjectReference>,
 
     /// Standard object's metadata.
-    pub metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+    pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 
     /// User is a reference to a user
     pub user: Option<k8s_openapi::api::core::v1::ObjectReference>,
@@ -270,8 +270,12 @@ impl k8s_openapi::Resource for UserIdentityMapping {
 impl k8s_openapi::Metadata for UserIdentityMapping {
     type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    fn metadata(&self) -> Option<&<Self as k8s_openapi::Metadata>::Ty> {
-        self.metadata.as_ref()
+    fn metadata(&self) -> &<Self as k8s_openapi::Metadata>::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut<Self as k8s_openapi::Metadata>::Ty {
+        &mut self.metadata
     }
 }
 
@@ -343,7 +347,7 @@ impl<'de> serde::Deserialize<'de> for UserIdentityMapping {
                             }
                         },
                         Field::Key_identity => value_identity = serde::de::MapAccess::next_value(&mut map)?,
-                        Field::Key_metadata => value_metadata = serde::de::MapAccess::next_value(&mut map)?,
+                        Field::Key_metadata => value_metadata = Some(serde::de::MapAccess::next_value(&mut map)?),
                         Field::Key_user => value_user = serde::de::MapAccess::next_value(&mut map)?,
                         Field::Other => { let _: serde::de::IgnoredAny = serde::de::MapAccess::next_value(&mut map)?; },
                     }
@@ -351,7 +355,7 @@ impl<'de> serde::Deserialize<'de> for UserIdentityMapping {
 
                 Ok(UserIdentityMapping {
                     identity: value_identity,
-                    metadata: value_metadata,
+                    metadata: value_metadata.ok_or_else(|| serde::de::Error::missing_field("metadata"))?,
                     user: value_user,
                 })
             }
@@ -375,9 +379,8 @@ impl serde::Serialize for UserIdentityMapping {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         let mut state = serializer.serialize_struct(
             <Self as k8s_openapi::Resource>::KIND,
-            2 +
+            3 +
             self.identity.as_ref().map_or(0, |_| 1) +
-            self.metadata.as_ref().map_or(0, |_| 1) +
             self.user.as_ref().map_or(0, |_| 1),
         )?;
         serde::ser::SerializeStruct::serialize_field(&mut state, "apiVersion", <Self as k8s_openapi::Resource>::API_VERSION)?;
@@ -385,9 +388,7 @@ impl serde::Serialize for UserIdentityMapping {
         if let Some(value) = &self.identity {
             serde::ser::SerializeStruct::serialize_field(&mut state, "identity", value)?;
         }
-        if let Some(value) = &self.metadata {
-            serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", value)?;
-        }
+        serde::ser::SerializeStruct::serialize_field(&mut state, "metadata", &self.metadata)?;
         if let Some(value) = &self.user {
             serde::ser::SerializeStruct::serialize_field(&mut state, "user", value)?;
         }


### PR DESCRIPTION
This PR migrates away from my patched k8s-openapi generator, and uses the enhanced k8s-openapi, which we can now use for generating OpenShift APIs as well.